### PR TITLE
Fix #3 Use localized text for the Chromecast button's accessibility text

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,9 +90,6 @@ player.chromecast(); // initializes the Chromecast plugin
 #### Configuration options
 
 ##### Plugin configuration
-* **`plugins.chromecast.buttonText`** - the text to display inside of the button
-  component. The text defaults to "Chromecast" and is used for accessibility purposes, so
-  it is visually hidden by default.
 * **`plugins.chromecast.receiverAppID`** - the string ID of a custom [Chromecast receiver
   app][cast-receiver] to use. Defaults to the [default Media Receiver ID][def-cast-id].
 
@@ -138,13 +135,22 @@ options = {
    },
    plugins: {
       chromecast: {
-         buttonText: 'Chromecast', // Not required
+         receiverAppID: '1234' // Not required
       },
-      receiverAppID: '1234' // Not required
    }
 };
 ```
 
+##### Localization
+
+The `ChromecastButton` component has one translated string: "Open Chromecast menu". The
+"Open Chromecast menu" string appears in both of the standard places for Button component
+accessibility text: inside the `.vjs-control-text` span and as the `<button>` element's
+`title` attribute.
+
+To localize the Chromecast button text, follow the steps in the
+[Video.js Languages tutorial][videojs-translation] to add an `"Open Chromecast menu"` key
+to the map of translation strings.
 
 ### Using the npm module
 
@@ -227,6 +233,7 @@ This software is released under the MIT license. See [the license file](LICENSE)
 details.
 
 [videojs-docs]: http://docs.videojs.com/tutorial-plugins.html
+[videojs-translation]: http://docs.videojs.com/tutorial-languages.html
 [cast-receiver]: https://developers.google.com/cast/docs/receiver_apps
 [def-cast-id]: https://developers.google.com/cast/docs/receiver_apps#default
 [player-source]: http://docs.videojs.com/Player.html#currentSource

--- a/src/js/components/ChromecastButton.js
+++ b/src/js/components/ChromecastButton.js
@@ -25,31 +25,15 @@ ChromecastButton = {
     *
     * @constructs
     * @extends external:Button
-    * @param options {object} the options to use for configuration
+    * @param player {Player} the video.js player instance
     */
-   constructor: function(player, options) {
-      // TODO internationalization
-      this._buttonText = options.buttonText || 'Chromecast';
+   constructor: function(player) {
       this.constructor.super_.apply(this, arguments);
 
       player.on('chromecastConnected', this._onChromecastConnected.bind(this));
       player.on('chromecastDisconnected', this._onChromecastDisconnected.bind(this));
-   },
 
-   /**
-    * Overrides Button#createControlTextEl to create the DOM element that contains the
-    * text within the button that is used for accessibility.
-    *
-    * @param el {DOMElement}
-    * @see {@link http://docs.videojs.com/Button.html#createControlTextEl|Button#createControlTextEl}
-    */
-   createControlTextEl: function(el) {
-      var textEl = document.createElement('span');
-
-      textEl.innerHTML = this._buttonText;
-      textEl.className = 'vjs-control-text';
-
-      el.appendChild(textEl);
+      this.controlText('Open Chromecast menu');
    },
 
    /**


### PR DESCRIPTION
This PR makes the Chromecast Button Component's text localizable, and removes the `buttonText` option. Alternative button text should be provided via the languages API. The README is updated to reflect those changes.

Additionally, an error in the placement of the `receiverAppID` option in the example configuration options is corrected.