### PR TITLE
Refs #11 Specify poster width to avoid conflicts with site-wide image styling

### DIFF
--- a/src/scss/_tech.scss
+++ b/src/scss/_tech.scss
@@ -26,6 +26,7 @@ $chromecast-poster-max-height: 180px !default;
    }
    .vjs-tech-chromecast-poster-img {
       max-height: $chromecast-poster-max-height;
+      width: auto;
       border: 2px solid $chromecast-color-main;
       &.vjs-tech-chromecast-poster-img-empty {
          width: 160px;


### PR DESCRIPTION
It's common practice to style images site-wide with a default width of 100%. Because the poster image defines a max-height but does not specify a width, the poster image will stretch to 100% in this case. The intent of the poster styling is to keep the poster at a maximum height, but constrained to its original ratio.