### PR TITLE
Preload webcomponents.js to prevent race with jQuery

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,15 @@ process directly, or you can install the plugin as an npm module, include the
 javascript and SCSS source in your project using a Common-JS module loader and SASS build
 process, and copy the images from the image source folder to your project.
 
+Note that regardless of whether you are using this plugin via the pre-built JS or as a
+module, the Chromecast framework will need to be included after the plugin. For example:
+
+```html
+<script src="https://unpkg.com/video.js@6.1.0/dist/video.js"></script>
+<script src="./dist/silvermine-videojs-chromecast.min.js"></script>
+<script type="text/javascript" src="https://www.gstatic.com/cv/js/sender/v1/cast_sender.js?loadCastFramework=1"></script>
+```
+
 ### Building the plugin locally
 
    1. Either clone this repository or install the `silvermine-videojs-chromecast` module
@@ -42,6 +51,45 @@ Note: when adding the plugin's javascript to your web page, include the
 Video.js. The plugin's built javascript file expects there to be a reference to Video.js
 at `window.videojs` and will throw an error if it does not exist.
 
+### Initialization options
+
+* **`preloadWebComponents`** (default: `false`) - The Chromecast framework relies on the
+  `webcomponents.js` polyfill when a browser does not have `document.registerElement`.
+  If you are using jQuery, this polyfill must be loaded and initialized before jQuery is
+  initialized. Unfortunately, the Chromecast framework loads the `webcomponents.js`
+  polyfill via a dynamically created `<script>` tag. This causes a race condition (see
+  #17). Setting `preloadWebComponents` to `true` will make this plugin add the
+  `webcomponents.js` polyfill synchronously when the polyfill is needed. If you use the
+  `preloadWebComponents: true` option, you should make sure that this plugin is loaded
+  before jQuery. Then include the Chromecast framework after this plugin as you normally
+  would.
+
+  tl;dr: if you use jQuery, you should use the `preloadWebComponents: true` option in
+  this plugin.
+
+#### Providing initialization options via `require()`
+
+If requiring this plugin via NPM, any desired initialization options can be supplied to
+the constructor function exported by the module. For example:
+
+```js
+require('silvermine-videojs-chromecast')(videojs, { preloadWebComponents: true });
+```
+
+#### Providing initialization options via `<script>`
+
+If using the prebuilt JS, the initialization options can be provided via
+`window.SILVERMINE_VIDEOJS_CHROMECAST_CONFIG`. Note that these options need to be set
+before the `<script>` tag to include the plugin.
+
+```html
+<script>
+   window.SILVERMINE_VIDEOJS_CHROMECAST_CONFIG = {
+      preloadWebComponents: true,
+   };
+</script>
+<script src="path/to/silvermine-videojs-chromecast.js"></script>
+```
 
 ### Configuration
 

--- a/docs/demo/index.html
+++ b/docs/demo/index.html
@@ -5,9 +5,9 @@
    <title>silvermine-videojs-chromecast Demo</title>
    <link href="https://unpkg.com/video.js@6.1.0/dist/video-js.css" rel="stylesheet">
    <script src="https://unpkg.com/video.js@6.1.0/dist/video.js"></script>
-   <script type="text/javascript" src="https://www.gstatic.com/cv/js/sender/v1/cast_sender.js?loadCastFramework=1"></script>
    <script src="../../dist/silvermine-videojs-chromecast.min.js"></script>
    <link href="../../dist/silvermine-videojs-chromecast.css" rel="stylesheet">
+   <script type="text/javascript" src="https://www.gstatic.com/cv/js/sender/v1/cast_sender.js?loadCastFramework=1"></script>
 </head>
 <body>
    <h1>Demo of <code>silvermine-videojs-chromecast</code></h1>

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
   "homepage": "https://github.com/silvermine/videojs-chromecast#readme",
   "dependencies": {
     "class.extend": "0.9.2",
-    "underscore": "1.8.3"
+    "underscore": "1.8.3",
+    "webcomponents.js": "git+https://git@github.com/webcomponents/webcomponentsjs.git#v0.7.24"
   },
   "devDependencies": {
     "autoprefixer": "7.1.1",

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -1,7 +1,9 @@
 /* eslint-disable global-require */
 'use strict';
 
-var createChromecastButton = require('./components/ChromecastButton'),
+var _ = require('underscore'),
+    preloadWebComponents = require('./preloadWebComponents'),
+    createChromecastButton = require('./components/ChromecastButton'),
     createChromecastTech = require('./tech/ChromecastTech'),
     enableChromecast = require('./enableChromecast');
 
@@ -14,11 +16,19 @@ var createChromecastButton = require('./components/ChromecastButton'),
  * {@link module:ChromecastButton} and {@link module:enableChromecast} for more details
  * about how the plugin and button are registered and configured.
  *
- * @param {object} videojs
+ * @param videojs {object} the videojs library. If `undefined`, this plugin
+ * will look to `window.videojs`.
+ * @param userOpts {object} the options to use for configuration
  * @see module:enableChromecast
  * @see module:ChromecastButton
  */
-module.exports = function(videojs) {
+module.exports = function(videojs, userOpts) {
+   var options = _.defaults(_.extend({}, userOpts), { preloadWebComponents: false });
+
+   if (options.preloadWebComponents) {
+      preloadWebComponents();
+   }
+
    videojs = videojs || window.videojs;
    createChromecastButton(videojs);
    createChromecastTech(videojs);

--- a/src/js/preloadWebComponents.js
+++ b/src/js/preloadWebComponents.js
@@ -1,0 +1,28 @@
+'use strict';
+
+var _ = require('underscore');
+
+function doesUserAgentContainString(str) {
+   return _.isString(window.navigator.userAgent) && window.navigator.userAgent.indexOf(str) >= 0;
+}
+
+// For information as to why this is needed, please see:
+// https://github.com/silvermine/videojs-chromecast/issues/17
+
+module.exports = function() {
+   var needsWebComponents = !document.registerElement,
+       iosChrome = doesUserAgentContainString('CriOS'),
+       androidChrome;
+
+   androidChrome = doesUserAgentContainString('Android')
+      && doesUserAgentContainString('Chrome/')
+      && window.navigator.presentation;
+
+   // These checks are based on the checks found in `cast_sender.js` which
+   // determine if `cast_framework.js` needs to be loaded
+   if ((androidChrome || iosChrome) && needsWebComponents) {
+      // This is requiring webcomponents.js@0.7.24 because that's what was used
+      // by the Chromecast framework at the time this was added.
+      require('webcomponents.js'); // eslint-disable-line global-require
+   }
+};

--- a/src/js/standalone.js
+++ b/src/js/standalone.js
@@ -3,4 +3,4 @@
 // This file is used to create a standalone javascript file for use in a script tag. The
 // file that is output assumes that Video.js is available at `window.videojs`.
 
-require('./index')();
+require('./index')(undefined, window.SILVERMINE_VIDEOJS_CHROMECAST_CONFIG);


### PR DESCRIPTION
This is to fix #17. The below command can be used to build a test case to verify this branch will actually fix the issue.

```bash
git clone git@github.com:silvermine/videojs-chromecast.git silvermine-videojs-chromecast
cd silvermine-videojs-chromecast
git checkout preload_webcomponents
curl -s https://gist.githubusercontent.com/onebytegone/941cb2a3128b474a63908b86b522dff6/raw/6bf15ce0eb41cc5a1629c353e8fba9b98e07cd98/jquery-webcomponents-conflict.html > docs/demo/jquery-webcomponents-conflict.html
npm install
grunt build
http-server -p 8080 -c-1
# Open http://IP_ADDRESS_HERE:8080/docs/demo/jquery-webcomponents-conflict.html in Chrome on iOS
``` 