### PR TITLE
Add Support for customData Object

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,12 +155,19 @@ player.chromecast(); // initializes the Chromecast plugin
   session is active and connected. When the this plugin calls the `requestSubtitleFn`, it
   passes it the [current `source` object][player-source] and expects a string in return.
   If nothing is returned or if this option is not defined, no sub-title will be shown.
+* **`chromecast.requestCustomDataFn`** - a function that this plugin calls when it needs an
+  object that contains custom information necessary for a Chromecast receiver app when a
+  session is active and connected. When the this plugin calls the `requestCustomDataFn`, it
+  passes it the [current `source` object][player-source] and expects an object in return.
+  If nothing is returned or if this option is not defined, no custom data will be sent.
+  This option is intended to be used with a [custom receiver][custom-receiver] application
+  to extend its default capabilities.
 
 Here is an example configuration object that makes full use of all required and optional
 configuration:
 
 ```js
-var titles, subtitles, options;
+var titles, subtitles, customData, options;
 
 titles = {
    'https://example.com/videos/video-1.mp4': 'Example Title',
@@ -170,6 +177,11 @@ titles = {
 subtitles = {
    'https://example.com/videos/video-1.mp4': 'Subtitle',
    'https://example.com/videos/video-2.mp4': 'Subtitle2',
+};
+
+customData = {
+   'https://example.com/videos/video-1.mp4': { 'customColor': '#0099ee' },
+   'https://example.com/videos/video-2.mp4': { 'customColor': '#000080' },
 };
 
 options = {
@@ -182,6 +194,9 @@ options = {
       },
       requestSubtitleFn: function(source) { // Not required
          return subtitles[source.url];
+      },
+      requestCustomDataFn: function(source) { // Not required
+         return customData[source.url];
       }
    },
    plugins: {
@@ -290,4 +305,5 @@ details.
 [cast-receiver]: https://developers.google.com/cast/docs/receiver_apps
 [def-cast-id]: https://developers.google.com/cast/docs/receiver_apps#default
 [player-source]: http://docs.videojs.com/Player.html#currentSource
+[custom-receiver]: https://developers.google.com/cast/docs/custom_receiver
 [contributing]: https://github.com/silvermine/silvermine-info#contributing

--- a/src/js/enableChromecast.js
+++ b/src/js/enableChromecast.js
@@ -152,6 +152,9 @@ function waitUntilChromecastAPIsAreAvailable(player, options) {
  *       },
  *       requestSubtitleFn: function(source) {
  *          return subtitles[source.url];
+ *       },
+ *       requestCustomDataFn: function(source) {
+ *          return customData[source.url];
  *       }
  *    }
  * };

--- a/src/js/tech/ChromecastTech.js
+++ b/src/js/tech/ChromecastTech.js
@@ -54,6 +54,7 @@ ChromecastTech = {
       this._hasPlayedAnyItem = false;
       this._requestTitle = options.requestTitleFn || _.noop;
       this._requestSubtitle = options.requestSubtitleFn || _.noop;
+      this._requestCustomData = options.requestCustomDataFn || _.noop;
       // See `currentTime` function
       this._initialStartTime = options.startTime || 0;
 
@@ -156,6 +157,7 @@ ChromecastTech = {
           mediaInfo = new chrome.cast.media.MediaInfo(source.src, source.type),
           title = this._requestTitle(source),
           subtitle = this._requestSubtitle(source),
+          customData = this._requestCustomData(source),
           request;
 
       this.trigger('waiting');
@@ -165,6 +167,9 @@ ChromecastTech = {
       mediaInfo.metadata.metadataType = chrome.cast.media.MetadataType.GENERIC;
       mediaInfo.metadata.title = title;
       mediaInfo.metadata.subtitle = subtitle;
+      if (customData) {
+         mediaInfo.customData = customData;
+      }
 
       this._ui.updateTitle(title);
       this._ui.updateSubtitle(subtitle);


### PR DESCRIPTION
Adds the ability to pass a customData object, which can contain licensing server urls and authentication tokens, to the Receiver app when casting media content.