### PR TITLE
Fixes #21 Replace webcomponents.js with webcomponents-lite.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,15 +54,27 @@ at `window.videojs` and will throw an error if it does not exist.
 ### Initialization options
 
 * **`preloadWebComponents`** (default: `false`) - The Chromecast framework relies on the
-  `webcomponents.js` polyfill when a browser does not have `document.registerElement`.
-  If you are using jQuery, this polyfill must be loaded and initialized before jQuery is
-  initialized. Unfortunately, the Chromecast framework loads the `webcomponents.js`
-  polyfill via a dynamically created `<script>` tag. This causes a race condition (see
-  #17). Setting `preloadWebComponents` to `true` will make this plugin add the
-  `webcomponents.js` polyfill synchronously when the polyfill is needed. If you use the
-  `preloadWebComponents: true` option, you should make sure that this plugin is loaded
-  before jQuery. Then include the Chromecast framework after this plugin as you normally
-  would.
+  `webcomponents.js` polyfill when a browser does not have `document.registerElement` in
+  order to create the `<google-cast-button>` custom component (which is not used by this
+  plugin).  If you are using jQuery, this polyfill must be loaded and initialized before
+  jQuery is initialized. Unfortunately, the Chromecast framework loads the
+  `webcomponents.js` polyfill via a dynamically created `<script>` tag. This causes a race
+  condition (see #17). Also, including `webcomponents.js` anywhere on the page will break
+  jQuery's fix for bubbling some events to `document` (e.g. `onchange` events for
+  `<select>`, see #21).  Setting `preloadWebComponents` to `true` will "fix" these 2
+  problems by (1) making this plugin add the `webcomponents` polyfill synchronously when
+  the polyfill is needed and (2) using the `webcomponents-lite.js` version as it does not
+  include the shadow DOM polyfills, but still provides the `registerElement` polyfill that
+  the Chromecast framework needs. If you use the `preloadWebComponents: true` option, you
+  should make sure that this plugin is loaded before jQuery. Then include the Chromecast
+  framework after this plugin as you normally would.
+
+  **Note:** There is a caveat to using the `preloadWebComponents` setting.
+  Because the Chromecast plugin uses the shadow DOM to create the
+  `<google-cast-button>` custom component, **the `<google-cast-button>` custom
+  component may partly render, but it will not be functional**. This tag is not
+  used by this plugin. However if you must use this tag elsewhere, you should
+  not use the `preloadWebComponents` flag.
 
   tl;dr: if you use jQuery, you should use the `preloadWebComponents: true` option in
   this plugin.

--- a/src/js/preloadWebComponents.js
+++ b/src/js/preloadWebComponents.js
@@ -8,6 +8,7 @@ function doesUserAgentContainString(str) {
 
 // For information as to why this is needed, please see:
 // https://github.com/silvermine/videojs-chromecast/issues/17
+// https://github.com/silvermine/videojs-chromecast/issues/22
 
 module.exports = function() {
    var needsWebComponents = !document.registerElement,
@@ -23,6 +24,12 @@ module.exports = function() {
    if ((androidChrome || iosChrome) && needsWebComponents) {
       // This is requiring webcomponents.js@0.7.24 because that's what was used
       // by the Chromecast framework at the time this was added.
-      require('webcomponents.js'); // eslint-disable-line global-require
+      // We are using webcomponents-lite.js because it doesn't interfere with jQuery as
+      // badly (e.g. it doesn't interfere with jQuery's fix for consistently bubbling
+      // events, see #21). While the "lite" version does not include the shadow DOM
+      // polyfills that the Chromecast framework may need for the <google-cast-button>
+      // component to work properly, this plugin does not use the <google-cast-button>
+      // component.
+      require('webcomponents.js/webcomponents-lite.js'); // eslint-disable-line global-require
    }
 };


### PR DESCRIPTION
The `webcompontents.js` polyfill, used by the Chromecast framework,
interferes significantly with jQuery. Especially jQuery's patch to
consitantly bubble events across browsers. In addition,
`webcomponents.js` polyfills much more than is needed by the framework.

The polyfill comes in a "lite" version (`webcomponents-lite.js`). This
version of the polyfill polyfills `registerElement`, but not the shadow
DOM. With this polyfill our plugin will work without interfering with
jQuery. However, the `<google-cast-button>` custom element will not
work. Since we don't use this element, we have determined that this is
the least of all evils.

This commit changes our include of `webcomponents.js` in
`preloadWebComponents` to include `webcomponents-lite.js` instead.