### PR TITLE
Refs #23 Add readyState function to Chromecast tech

### DIFF
--- a/src/js/tech/ChromecastTech.js
+++ b/src/js/tech/ChromecastTech.js
@@ -414,6 +414,18 @@ ChromecastTech = {
    },
 
    /**
+    * Gets the Chromecast equivalent of HTML5 Media Element's `readyState`.
+    *
+    * @see https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/readyState
+    */
+   readyState: function() {
+      if (this._remotePlayer.playerState === 'IDLE' || this._remotePlayer.playerState === 'BUFFERING') {
+         return 0; // HAVE_NOTHING
+      }
+      return 4;
+   },
+
+   /**
     * Wires up event listeners for
     * [RemotePlayerController](https://developers.google.com/cast/docs/reference/chrome/cast.framework.RemotePlayerController)
     * events.


### PR DESCRIPTION
Calling the Video.js player's `readyState` function while casting causes
an error with the message:

```
VIDEOJS: Video.js: readyState method not defined for Chromecast playback
technology. TypeError: this.tech_[t] is not a function
```

So, we add a `readyState` function to the Chromecast tech that returns
the best approximation that we can make about the media's "ready state".
If the media is buffering or idle (no media is loaded), we have to
assume the readyState is "HAVE_NOTHING" because even though the player
is buffering it may not have buffered any data and we have no way to
know how much data has been buffered. In all other cases, we say that
the state is "HAVE_ENOUGH_DATA".