### PR TITLE
Refs #25 Add a `playbackRate` function

### DIFF
--- a/src/js/tech/ChromecastTech.js
+++ b/src/js/tech/ChromecastTech.js
@@ -405,6 +405,23 @@ ChromecastTech = {
    },
 
    /**
+    * @returns {number} the chromecast player's playback rate, if available. Otherwise,
+    * the return value defaults to `1`.
+    */
+   playbackRate: function() {
+      var mediaSession = this._getMediaSession();
+
+      return mediaSession ? mediaSession.playbackRate : 1;
+   },
+
+   /**
+    * Does nothing. Changing the playback rate is not supported.
+    */
+   setPlaybackRate: function() {
+      // Not supported
+   },
+
+   /**
     * Causes the Tech to begin loading the current source. `load` is not supported in this
     * ChromecastTech because setting the source on the `Chromecast` automatically causes
     * it to begin loading.


### PR DESCRIPTION
While casting an HLS media item, this error is logged in the console
periodically:

```
VIDEOJS: ERROR: TypeError: _this2.tech_.playbackRate is not a function
```

This is because the
[ChromecastTech](https://github.com/silvermine/videojs-chromecast/blob/master/src/js/tech/ChromecastTech.js)
class does not implement a `playbackRate` function. So, we add a
`playbackRate` function, as well as a setter for the `playbackRate` that
does nothing because there's no way to change the `playbackRate` using
the default receiver app.