### PR TITLE
fix: missing preload function fixes

### DIFF
--- a/src/js/tech/ChromecastTech.js
+++ b/src/js/tech/ChromecastTech.js
@@ -427,6 +427,13 @@ ChromecastTech = {
    },
 
    /**
+    * Does nothing. Satisfies calls to the missing preload method.
+    */
+   preload: function() {
+      // Not supported
+   },
+
+   /**
     * Causes the Tech to begin loading the current source. `load` is not supported in this
     * ChromecastTech because setting the source on the `Chromecast` automatically causes
     * it to begin loading.


### PR DESCRIPTION
Here is the error that is thrown when MUX is present.

Mux is attempting: `tech_[preload]` 


VIDEOJS: Video.js: preload method not defined for Chromecast playback technology. TypeError: this.tech_[method] is not a function
    at Player.techGet_ (pac12_videojs.js?phqwzs:26117)
    at Player.preload (pac12_videojs.js?phqwzs:27127)
    at i (pac12_videojs.js?phqwzs:95595)
    at X.e.getStateData (pac12_videojs.js?phqwzs:95595)
    at X._updateStateData (pac12_videojs.js?phqwzs:95595)
    at X.<anonymous> (pac12_videojs.js?phqwzs:95595)
    at pac12_videojs.js?phqwzs:95595
    at Array.forEach (<anonymous>)
    at o (pac12_videojs.js?phqwzs:95595)
    at X.i.emit (pac12_videojs.js?phqwzs:95595)