### PR TITLE
feat: textTrack (e.g. subtitles) support, session restoring/resuming support

### DIFF
--- a/docs/demo/index.html
+++ b/docs/demo/index.html
@@ -3,17 +3,22 @@
 <head>
    <meta charset=utf-8 />
    <title>silvermine-videojs-chromecast Demo</title>
-   <link href="https://unpkg.com/video.js@6.1.0/dist/video-js.css" rel="stylesheet">
-   <script src="https://unpkg.com/video.js@6.1.0/dist/video.js"></script>
+   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/video.js/7.11.6/video-js.min.css" />
+   <script src="https://cdnjs.cloudflare.com/ajax/libs/video.js/7.11.6/video.js" ></script>
    <script src="../../dist/silvermine-videojs-chromecast.min.js"></script>
    <link href="../../dist/silvermine-videojs-chromecast.css" rel="stylesheet">
-   <script type="text/javascript" src="https://www.gstatic.com/cv/js/sender/v1/cast_sender.js?loadCastFramework=1"></script>
+   <script type="text/javascript" src="//www.gstatic.com/cv/js/sender/v1/cast_sender.js?loadCastFramework=1"></script>
 </head>
 <body>
    <h1>Demo of <code>silvermine-videojs-chromecast</code></h1>
 
-   <video id="video_1" class="video-js vjs-default-skin" controls preload="auto" data-setup='{ "fluid": "true" }'>
-      <source src="http://www.caminandes.com/download/03_caminandes_llamigos_1080p.mp4" type="video/mp4">
+   <video crossorigin="anonymous" id="video_1" class="video-js vjs-default-skin"  controls preload="auto" data-setup='{ "fluid": "true" }'>
+      <source src="https://storage.googleapis.com/webfundamentals-assets/videos/chrome.webm" type="video/webm" />
+      <source src="https://storage.googleapis.com/webfundamentals-assets/videos/chrome.mp4" type="video/mp4" />
+      <track src="https://track-demonstration.glitch.me/chrome-subtitles-en.vtt" label="English captions"
+             kind="captions" srclang="en" default>
+      <track src="https://track-demonstration.glitch.me/chrome-subtitles-zh.vtt" label="中文字幕"
+             kind="captions" srclang="zh">
    </video>
 
    <script>
@@ -28,6 +33,7 @@
 
          player.chromecast();
       });
+
    </script>
 
 </body>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@silvermine/videojs-chromecast",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "video.js plugin for casting to chromecast",
   "main": "src/js/index.js",
   "scripts": {

--- a/src/js/enableChromecast.js
+++ b/src/js/enableChromecast.js
@@ -28,6 +28,7 @@ function configureCastContext(options) {
       // must end any existing session before trying to cast from this player instance.
       autoJoinPolicy: chrome.cast.AutoJoinPolicy.ORIGIN_SCOPED,
    });
+
 }
 
 /**
@@ -42,8 +43,8 @@ function onChromecastRequested(player) {
 }
 
 /**
- * Adds the Chromecast button to the player's control bar, if one does not already exist,
- * then starts listening for the `chromecastRequested` event.
+ * Adds the Chromecast button to the player's control bar, if one does not already
+ * exist, then starts listening for the `chromecastRequested` event
  *
  * @private
  * @param player {object} a Video.js player instance

--- a/src/js/tech/ChromecastTech.js
+++ b/src/js/tech/ChromecastTech.js
@@ -859,8 +859,8 @@ module.exports = function(videojs) {
    ChromecastTechImpl.prototype.featuresTimeupdateEvents = true;
    ChromecastTechImpl.prototype.featuresProgressEvents = false;
    ChromecastTechImpl.prototype.featuresNativeTextTracks = false;
-   ChromecastTechImpl.prototype.featuresNativeAudioTracks = true;
-   ChromecastTechImpl.prototype.featuresNativeVideoTracks = true;
+   ChromecastTechImpl.prototype.featuresNativeAudioTracks = false;
+   ChromecastTechImpl.prototype.featuresNativeVideoTracks = false;
 
    // Give ChromecastTech class instances a reference to videojs
    ChromecastTechImpl.prototype.videojs = videojs;


### PR DESCRIPTION
### TextTrack support
Added support for textTracks (e.g. subtitles, captions, descriptions). The active track will automatically be enabled on chromecast. Switching and disabling works. For details, see https://developers.google.com/cast/docs/chrome_sender/advanced#using_the_tracks_apis
https://developers.google.com/cast/docs/reference/chrome/chrome.cast.media.Track
https://developers.google.com/cast/docs/reference/chrome/chrome.cast.media.Media#editTracksInfo

### Session restoring/resuming
Added support for restoring chromecast sessions. E.g. when a user refreshes/reloads the player, it will automatically restore its state as if no refresh happened. 
See https://developers.google.com/cast/docs/chrome_sender/integrate