### PR TITLE
fix: clean event listeners on player.dispose() (#97)

### DIFF
--- a/src/js/chromecast/ChromecastSessionManager.js
+++ b/src/js/chromecast/ChromecastSessionManager.js
@@ -40,6 +40,9 @@ ChromecastSessionManager = Class.extend(/** @lends ChromecastSessionManager.prot
    init: function(player) {
       this.player = player;
 
+      this._sessionListener = this._onSessionStateChange.bind(this);
+      this._castListener = this._onCastStateChange.bind(this);
+
       this._addCastContextEventListeners();
 
       // Remove global event listeners when this player instance is destroyed to prevent
@@ -61,8 +64,8 @@ ChromecastSessionManager = Class.extend(/** @lends ChromecastSessionManager.prot
       var sessionStateChangedEvt = cast.framework.CastContextEventType.SESSION_STATE_CHANGED,
           castStateChangedEvt = cast.framework.CastContextEventType.CAST_STATE_CHANGED;
 
-      this.getCastContext().addEventListener(sessionStateChangedEvt, this._onSessionStateChange.bind(this));
-      this.getCastContext().addEventListener(castStateChangedEvt, this._onCastStateChange.bind(this));
+      this.getCastContext().addEventListener(sessionStateChangedEvt, this._sessionListener);
+      this.getCastContext().addEventListener(castStateChangedEvt, this._castListener);
    },
 
    /**
@@ -75,8 +78,8 @@ ChromecastSessionManager = Class.extend(/** @lends ChromecastSessionManager.prot
       var sessionStateChangedEvt = cast.framework.CastContextEventType.SESSION_STATE_CHANGED,
           castStateChangedEvt = cast.framework.CastContextEventType.CAST_STATE_CHANGED;
 
-      this.getCastContext().removeEventListener(sessionStateChangedEvt);
-      this.getCastContext().removeEventListener(castStateChangedEvt);
+      this.getCastContext().removeEventListener(sessionStateChangedEvt, this._sessionListener);
+      this.getCastContext().removeEventListener(castStateChangedEvt, this._castListener);
    },
 
    /**


### PR DESCRIPTION
Hello videojs-chromecast maintainers,

I humbly request for this fix to be added to the baseline of the chromecast plugin. This addresses the [issue](https://github.com/silvermine/videojs-chromecast/issues/97) I found pertaining to memory leaks from the event listeners in the ChromecastSessionManager. Source for the problem and solution I came up with may be found [here](https://stackoverflow.com/q/11565471).

Reduced test case can be found [here](https://codepen.io/wassing/pen/qBrQQab), to reproduce the error that this pull request fixes, open console manager, press mute button on the started player (this disposes the player), tab into another browser tab, tab back in, and you will see that the console produces errors because the event listeners have not properly detached.

I am still fairly new to web development, so I'm not entirely sure how else this can be solved than with the global variables introduced on lines 7 and 8. If you have a better solution, I would very much like to hear it.

Kind regards,
Daniel