### PR TITLE
[FIX] SCSS Division deprecation warning 

### DIFF
--- a/src/scss/_tech.scss
+++ b/src/scss/_tech.scss
@@ -21,7 +21,7 @@ $chromecast-poster-max-height: 180px !default;
          width: $chromecast-poster-width;
          background-color: $chromecast-color-main;
          position: absolute;
-         left: calc(50% - #{$chromecast-poster-width * .5});
+         left: calc(50% - #{$chromecast-poster-width * 0.5});
       }
    }
    .vjs-tech-chromecast-poster-img {

--- a/src/scss/_tech.scss
+++ b/src/scss/_tech.scss
@@ -21,7 +21,7 @@ $chromecast-poster-max-height: 180px !default;
          width: $chromecast-poster-width;
          background-color: $chromecast-color-main;
          position: absolute;
-         left: calc(50% - #{$chromecast-poster-width / 2});
+         left: calc(50% - #{$chromecast-poster-width * .5});
       }
    }
    .vjs-tech-chromecast-poster-img {


### PR DESCRIPTION
Fixes #100 

Since dividing number by 2 is the same as multiplying it by 0.5, this fix will work great in current and next sass major version.

