### PR TITLE
fix: scss deprecation warning

### DIFF
--- a/src/scss/_tech.scss
+++ b/src/scss/_tech.scss
@@ -21,7 +21,7 @@ $chromecast-poster-max-height: 180px !default;
          width: $chromecast-poster-width;
          background-color: $chromecast-color-main;
          position: absolute;
-         left: calc(50% - #{$chromecast-poster-width / 2});
+         left: calc(50% - #{$chromecast-poster-width * 0.5});
       }
    }
    .vjs-tech-chromecast-poster-img {


### PR DESCRIPTION
Fixes #100

Since dividing number by 2 is the same as multiplying it by 0.5, this fix will work great in current and next sass major version.

P.s. sorry about previous PR. After travis failed because of commit messages, I read everything in Contribution section and decided to close it, because probably it wouldn't be merged. 