### PR TITLE
feat: textTrack (e.g. subtitles) support, session restoring/resuming support

### DIFF
--- a/docs/demo/index.html
+++ b/docs/demo/index.html
@@ -7,13 +7,18 @@
    <script src="https://unpkg.com/video.js@6.1.0/dist/video.js"></script>
    <script src="../../dist/silvermine-videojs-chromecast.min.js"></script>
    <link href="../../dist/silvermine-videojs-chromecast.css" rel="stylesheet">
-   <script type="text/javascript" src="https://www.gstatic.com/cv/js/sender/v1/cast_sender.js?loadCastFramework=1"></script>
+   <script type="text/javascript" src="//www.gstatic.com/cv/js/sender/v1/cast_sender.js?loadCastFramework=1"></script>
 </head>
 <body>
    <h1>Demo of <code>silvermine-videojs-chromecast</code></h1>
 
    <video id="video_1" class="video-js vjs-default-skin" controls preload="auto">
-      <source src="http://www.caminandes.com/download/03_caminandes_llamigos_1080p.mp4" type="video/mp4">
+      <source src="https://storage.googleapis.com/webfundamentals-assets/videos/chrome.webm" type="video/webm" />
+      <source src="https://storage.googleapis.com/webfundamentals-assets/videos/chrome.mp4" type="video/mp4" />
+      <track src="https://track-demonstration.glitch.me/chrome-subtitles-en.vtt" label="English captions"
+             kind="captions" srclang="en" default>
+      <track src="https://track-demonstration.glitch.me/chrome-subtitles-zh.vtt" label="中文字幕"
+             kind="captions" srclang="zh">
    </video>
 
    <script>


### PR DESCRIPTION
version of #89 with resolved conflicts and review changes

---

_original PR comment by @jbreemhaar:_

### TextTrack support

Added support for textTracks (e.g. subtitles, captions, descriptions). The active track will automatically be enabled on chromecast. Switching and disabling works. For details, see https://developers.google.com/cast/docs/chrome_sender/advanced#using_the_tracks_apis
https://developers.google.com/cast/docs/reference/chrome/chrome.cast.media.Track
https://developers.google.com/cast/docs/reference/chrome/chrome.cast.media.Media#editTracksInfo

### Session restoring/resuming

Added support for restoring chromecast sessions. E.g. when a user refreshes/reloads the player, it will automatically restore its state as if no refresh happened.
See https://developers.google.com/cast/docs/chrome_sender/integrate