### PR TITLE
Remove usage of obsolete videojs.extend()

### DIFF
--- a/src/js/components/ChromecastButton.js
+++ b/src/js/components/ChromecastButton.js
@@ -176,8 +176,7 @@ ChromecastButton = {
  * @see http://docs.videojs.com/module-videojs.html#~registerPlugin
  */
 module.exports = function(videojs) {
-   var ChromecastButtonImpl;
+   class ChromecastButtonImpl extends videojs.getComponent('Button') {ChromecastButton};
 
-   ChromecastButtonImpl = videojs.extend(videojs.getComponent('Button'), ChromecastButton);
    videojs.registerComponent('chromecastButton', ChromecastButtonImpl);
 };

--- a/src/js/tech/ChromecastTech.js
+++ b/src/js/tech/ChromecastTech.js
@@ -738,10 +738,9 @@ ChromecastTech = {
  * @see http://docs.videojs.com/Tech.html#.registerTech
  */
 module.exports = function(videojs) {
-   var Tech = videojs.getComponent('Tech'),
-       ChromecastTechImpl;
+   var Tech = videojs.getComponent('Tech');
 
-   ChromecastTechImpl = videojs.extend(Tech, ChromecastTech);
+   class ChromecastTechImpl extends Tech {ChromecastTech};
 
    // Required for Video.js Tech implementations.
    // TODO Consider a more comprehensive check based on mimetype.


### PR DESCRIPTION
videojs.extend is deprecated as of Video.js 7.22.0 and was removed in Video.js 8.0.0