### PR TITLE
fix: clear session disconnect timeout on Chromecast Tech dispose

### DIFF
--- a/src/js/tech/ChromecastTech.js
+++ b/src/js/tech/ChromecastTech.js
@@ -69,7 +69,10 @@ module.exports = function(videojs) {
          this._remotePlayer = this._chromecastSessionManager.getRemotePlayer();
          this._remotePlayerController = this._chromecastSessionManager.getRemotePlayerController();
          this._listenToPlayerControllerEvents();
-         this.on('dispose', this._removeAllEventListeners.bind(this));
+         this.on('dispose', () => {
+            this._clearSessionTimeout();
+            this._removeAllEventListeners();
+         });
 
          this._hasPlayedAnyItem = false;
          this._requestTitle = options.requestTitleFn || function() { /* noop */ };


### PR DESCRIPTION
Because the timer was not cleared even after ChromeTech was dispose.