### PR TITLE
fix: Clear the close session timeout after new source starts playing

### DIFF
--- a/src/js/tech/ChromecastTech.js
+++ b/src/js/tech/ChromecastTech.js
@@ -214,6 +214,7 @@ module.exports = function(videojs) {
          this._hasPlayedCurrentItem = false;
          castSession.loadMedia(request)
             .then(function() {
+               this._clearSessionTimeout();
                if (!this._hasPlayedAnyItem) {
                   // `triggerReady` is required here to notify the Video.js
                   // player that the Tech has been initialized and is ready.


### PR DESCRIPTION
Fixes bug where `castSession` is null when calling `castSession.loadMedia()`

When the ChromeCast player state reaches an `IDLE` state, a timeout will start to close the session after `SESSION_TIMEOUT` (default is 10 seconds) has elapsed.

After calling `_playSource()` this close session timeout is cleared. However, when playing a new source, the player state will go from `PAUSED` → `IDLE` → `BUFFERING` → `PLAYING`.

There is a listener for the `IDLE` state that starts the close session timeout. With the current order of player state changes, this could cause the casting session to close while the new source is being played, even if we are in the `PLAYING` state.

To prevent this from occurring, we can clear the session timeout when `castSession.loadMedia()` finishes.